### PR TITLE
Change scibert_data_dir to "bert_model"

### DIFF
--- a/benchmarks/pubmed_sentence_classifier/convert_to_classifier_input.py
+++ b/benchmarks/pubmed_sentence_classifier/convert_to_classifier_input.py
@@ -58,7 +58,7 @@ def parse_raw_file(raw_file_path:Path)->Iterable[Record]:
 
 if __name__ == "__main__":
   parser = ArgumentParser()
-  parser.add_argument("--bert_data_dir", type=Path)
+  parser.add_argument("--bert_model", type=str)
   parser.add_argument("--in_data_dir", type=Path)
   parser.add_argument("--out_data_dir", type=Path)
   parser.add_argument("--disable_gpu", action="store_true")
@@ -96,8 +96,8 @@ if __name__ == "__main__":
   preloader.register(*embedding_util.get_pytorch_device_initalizer(
       disable_gpu=args.disable_gpu,
   ))
-  preloader.register(*embedding_util.get_scibert_initializer(
-      scibert_data_dir=args.bert_data_dir,
+  preloader.register(*embedding_util.get_bert_initializer(
+      bert_model=args.bert_model,
   ))
   dpg.add_global_preloader(preloader=preloader)
 

--- a/pymoliere/config/config.proto
+++ b/pymoliere/config/config.proto
@@ -27,7 +27,9 @@ message ClusterConfig {
 
 message TextParserConfig {
   optional string scispacy_version = 1;
-  optional string scibert_data_dir = 2;
+  // May be a path to a bert model, or any of the transformer pretrained models.
+  // Example: "./data/scibert" or "bert-base-uncased"
+  optional string bert_model = 2 [default="bert-base-uncased"];
   // Discard sentences that are too long/short
   optional int32 min_sentence_len = 3 [default=10];
   optional int32 max_sentence_len = 4 [default=1000];

--- a/pymoliere/construct/__main__.py
+++ b/pymoliere/construct/__main__.py
@@ -130,8 +130,8 @@ if __name__ == "__main__":
   preloader.register(*embedding_util.get_pytorch_device_initalizer(
       disable_gpu=config.sys.disable_gpu,
   ))
-  preloader.register(*embedding_util.get_scibert_initializer(
-      scibert_data_dir=config.parser.scibert_data_dir,
+  preloader.register(*embedding_util.get_bert_initializer(
+      bert_model=config.parser.bert_model,
   ))
   preloader.register(*write_db.get_redis_client_initialzizer(
       host=config.db.address,

--- a/pymoliere/construct/embedding_util.py
+++ b/pymoliere/construct/embedding_util.py
@@ -31,13 +31,17 @@ def get_pytorch_device_initalizer(
       return torch.device("cpu")
   return "embedding_util:device", _init
 
-def get_scibert_initializer(
-    scibert_data_dir:Path,
+def get_bert_initializer(
+    bert_model:str,
 )->Tuple[str, dpg.Initializer]:
+  """
+  The bert_model may be a path or any provided by the transformers module.
+  For instance "bert-base-uncased"
+  """
   def _init():
     device = dpg.get("embedding_util:device")
-    tok = BertTokenizer.from_pretrained(scibert_data_dir)
-    model = BertModel.from_pretrained(scibert_data_dir)
+    tok = BertTokenizer.from_pretrained(bert_model)
+    model = BertModel.from_pretrained(bert_model)
     model.eval()
     model.to(device)
     return (tok, model)
@@ -96,7 +100,7 @@ def embed_records(
     show_pbar:bool=False,
 )->Iterable[Record]:
   """
-  Introduces an embedding field to each record, indicated the scibert embedding
+  Introduces an embedding field to each record, indicated the bert embedding
   of the supplied text field.
   """
 


### PR DESCRIPTION
The initializer in the embedding_util was used to load scibert model paths. However, as written it could not load easily downloadable baselines such as "bert-base-uncased" which are provided by the transformers model. This was because the transformers model is doing a dict lookup, and we passed in paths.

Now, the user is free to specify general bert models, or paths in either form.


Testing:

The conversion script works:

With base model
```
./convert_to_classifier_input.py   --bert_model bert-base-uncased   --in_data_dir raw_data/PubMed_20k_RCT   --out_data_dir data/bert_data
```

With Scibert
```
 ./convert_to_classifier_input.py --bert_model ../../data/scibert_scivocab_uncased/ --in_data_dir raw_data/PubMed_20k_RCT --out_data_dir data/
```


Pymoliere.construct works:
```
 python3 -m pymoliere.construct configs/debug_construct.conf --parser.bert_model bert-base-uncased
```
```
 python3 -m pymoliere.construct configs/debug_construct.conf --parser.bert_model ../../data/scibert_scivocab_uncased/
```